### PR TITLE
Use https instead of http

### DIFF
--- a/account-link.js
+++ b/account-link.js
@@ -3,6 +3,6 @@ const prefixForNetwork = require('./prefix-for-network')
 module.exports = function (address, network) {
   const net = parseInt(network)
   const prefix = prefixForNetwork(network)
-  return `http://${prefix}etherscan.io/address/${address}`
+  return `https://${prefix}etherscan.io/address/${address}`
 }
 

--- a/explorer-link.js
+++ b/explorer-link.js
@@ -2,5 +2,5 @@ const prefixForNetwork = require('./prefix-for-network')
 
 module.exports = function (hash, network) {
   const prefix = prefixForNetwork(network)
-  return `http://${prefix}etherscan.io/tx/${hash}`
+  return `https://${prefix}etherscan.io/tx/${hash}`
 }


### PR DESCRIPTION
Right now the links used by the MetaMask extension use `http`. 