### PR TITLE
Fix build script, add prepublishOnly script

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dist/"
   ],
   "scripts": {
-    "build": "rm dist/* && tsc",
+    "build": "rm -rf dist/* && tsc",
     "test": "yarn build && mocha"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   ],
   "scripts": {
     "build": "rm -rf dist/* && tsc",
-    "test": "yarn build && mocha"
+    "test": "yarn build && mocha",
+    "prepublishOnly": "yarn test"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Handle empty/non-existing `dist` folder in `build` script
- Add `prepublishOnly` script