### PR TITLE
Add Goerli Testnet

### DIFF
--- a/src/prefix-for-network.ts
+++ b/src/prefix-for-network.ts
@@ -12,6 +12,9 @@ export = function getPrefixForNetwork(network: string): string {
     case 4: // rinkeby test net
       prefix = 'rinkeby.'
       break
+    case 5: // kovan test net
+      prefix = 'goerli.'
+      break
     case 42: // kovan test net
       prefix = 'kovan.'
       break

--- a/src/prefix-for-network.ts
+++ b/src/prefix-for-network.ts
@@ -12,7 +12,7 @@ export = function getPrefixForNetwork(network: string): string {
     case 4: // rinkeby test net
       prefix = 'rinkeby.'
       break
-    case 5: // kovan test net
+    case 5: // goerli test net
       prefix = 'goerli.'
       break
     case 42: // kovan test net


### PR DESCRIPTION
Metamask supports Goerli test network, but when a transaction is successful the desktop notification doesn't direct you to  [goerli.etherscan](https://goerli.etherscan.io/), instead It directs you to default option: [etherscan](https://etherscan.io/).

Problem fixed by:
- Adding goerli testnet with network Id: 5.