### PR TITLE
Added Custom Network conditional

### DIFF
--- a/src/account-link.ts
+++ b/src/account-link.ts
@@ -2,5 +2,5 @@ import prefixForNetwork from './prefix-for-network'
 
 export = function getAccountLink(address: string, network: string): string {
   const prefix = prefixForNetwork(network)
-  return `https://${prefix}etherscan.io/address/${address}`
+  return prefix !== null ? `https://${prefix}etherscan.io/address/${address}` : '';
 }

--- a/src/explorer-link.ts
+++ b/src/explorer-link.ts
@@ -2,5 +2,5 @@ import prefixForNetwork from './prefix-for-network'
 
 export = function getExplorerLink(hash: string, network: string): string {
   const prefix = prefixForNetwork(network)
-  return `https://${prefix}etherscan.io/tx/${hash}`
+  return (prefix !== 'other.' ?`https://${prefix}etherscan.io/tx/${hash}`: '');
 }

--- a/src/explorer-link.ts
+++ b/src/explorer-link.ts
@@ -2,5 +2,5 @@ import prefixForNetwork from './prefix-for-network'
 
 export = function getExplorerLink(hash: string, network: string): string {
   const prefix = prefixForNetwork(network)
-  return (prefix !== 'other.' ?`https://${prefix}etherscan.io/tx/${hash}`: '');
+  return prefix !== null ?`https://${prefix}etherscan.io/tx/${hash}`: '';
 }

--- a/src/explorer-link.ts
+++ b/src/explorer-link.ts
@@ -2,5 +2,5 @@ import prefixForNetwork from './prefix-for-network'
 
 export = function getExplorerLink(hash: string, network: string): string {
   const prefix = prefixForNetwork(network)
-  return prefix !== null ?`https://${prefix}etherscan.io/tx/${hash}`: '';
+  return prefix !== null ? `https://${prefix}etherscan.io/tx/${hash}`: '';
 }

--- a/src/prefix-for-network.ts
+++ b/src/prefix-for-network.ts
@@ -1,4 +1,4 @@
-export = function getPrefixForNetwork(network: string): string {
+export = function getPrefixForNetwork(network: string): string | null {
   const net = parseInt(network)
   let prefix;
 
@@ -19,7 +19,7 @@ export = function getPrefixForNetwork(network: string): string {
       prefix = 'kovan.'
       break
     default:
-      prefix = 'other.'
+      prefix = null
   }
   return prefix
 }

--- a/src/prefix-for-network.ts
+++ b/src/prefix-for-network.ts
@@ -19,7 +19,7 @@ export = function getPrefixForNetwork(network: string): string {
       prefix = 'kovan.'
       break
     default:
-      prefix = ''
+      prefix = 'other.'
   }
   return prefix
 }

--- a/src/token-tracker-link.ts
+++ b/src/token-tracker-link.ts
@@ -6,7 +6,8 @@ export = function getTokenTrackerLink(
   holderAddress?: string,
 ): string {
   const prefix = prefixForNetwork(network)
-  return `https://${prefix}etherscan.io/token/${tokenAddress}${
-    holderAddress ? `?a=${ holderAddress }` : ''
-  }`
+  return prefix !== null ? 
+      `https://${prefix}etherscan.io/token/${tokenAddress}${ 
+        holderAddress ? `?a=${ holderAddress }` : '' }`
+    : '';
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -16,6 +16,11 @@ describe('account-link', function () {
     const result = createAccountLink('foo', '3')
     assert.strictEqual(result, 'https://ropsten.etherscan.io/address/foo', 'should handle ropsten')
   })
+
+  it('should have null as a prefix', function () {
+    const result = createAccountLink('foo', '3234')
+    assert.strictEqual(result, '', 'should return an empty string')
+  })
 })
 
 // `https://${prefix}etherscan.io/tx/${hash}`
@@ -30,9 +35,9 @@ describe('explorer-link', function () {
     assert.strictEqual(result, 'https://ropsten.etherscan.io/tx/foo', 'should handle ropsten')
   })
 
-  it('should handle have other as a prefix', function () {
+  it('should have null as a prefix', function () {
     const result = createExplorerLink('foo', '10')
-    assert.strictEqual(result, '', 'should return null')
+    assert.strictEqual(result, '', 'should return an empty string')
   })
 })
 
@@ -60,5 +65,10 @@ describe('token-tracker-link', function () {
   it('should handle ropsten correctly (account)', function () {
     const result = createTokenTrackerLink('foo', '3', '0xabc')
     assert.strictEqual(result, 'https://ropsten.etherscan.io/token/foo?a=0xabc', 'should handle ropsten')
+  })
+
+  it('should null has a prefix', function () {
+    const result = createTokenTrackerLink('foo', '3654', '0xabc')
+    assert.strictEqual(result, '', 'should return an empty string')
   })
 })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -29,6 +29,11 @@ describe('explorer-link', function () {
     const result = createExplorerLink('foo', '3')
     assert.strictEqual(result, 'https://ropsten.etherscan.io/tx/foo', 'should handle ropsten')
   })
+
+  it('should handle have other as a prefix', function () {
+    const result = createExplorerLink('foo', '10')
+    assert.strictEqual(result, '', 'should return an empty string')
+  })
 })
 
 /**

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -32,7 +32,7 @@ describe('explorer-link', function () {
 
   it('should handle have other as a prefix', function () {
     const result = createExplorerLink('foo', '10')
-    assert.strictEqual(result, '', 'should return an empty string')
+    assert.strictEqual(result, '', 'should return null')
   })
 })
 


### PR DESCRIPTION
Custom networks now return an empty url string instead of broken etherscan url when passed in a custom network id.
This PR builds on top of this Github Issue and should fix the broken etherscan url for custom networks. https://github.com/MetaMask/metamask-extension/issues/5631