### PR TITLE
v1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.1] - 2021-02-16
+
+### Changed
+
+- Return an empty string for unrecognized networks ([#29](https://github.com/MetaMask/etherscan-link/pull/29))
+
 ## [1.4.0] - 2020-12-01
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/etherscan-link",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "A library for generating etherscan links.",
   "main": "dist/index.js",
   "publishConfig": {


### PR DESCRIPTION
I decided to consider #29 as non-breaking, as the type signature hasn't changed, and previously the link we would return was blatantly wrong. If anyone gets this update without handling the empty string case, their use will still be less broken now, arguably.