### PR TITLE
Added custom ethereum network url generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 
 ```javascript
 const etherscanLink = require('@metamask/etherscan-link')
-
 const networkId = '1'
 const account = '0xFDEa65C8e26263F6d9A1B5de9555D2931A33b825'
 const accountLink = etherscanLink.createAccountLink(account, networkId)
@@ -20,4 +19,14 @@ const token = '0xdac17f958d2ee523a2206206994597c13d831ec7'
 const tokenTrackerLink = etherscanLink.createTokenTrackerLink(token, networkId)
 // You can also track token balances by account
 const accountTokenTrackerLink = etherscanLink.createTokenTrackerLink(token, networkId, account)
+
+
+// Create urls for interacting with custom networks
+const customNetworkUrl = 'https://customnetwork.com/'
+
+const customtTokenTrackerLink = etherscanLink.createCustomTokenTrackerLink(token, customNetworkUrl)
+
+const customAccountLink = etherscanLink.createCustomAccountLink(account, customNetworkUrl)
+
+const customExplorerLink = etherscanLink.createCustomExplorerLink(hash, customNetworkUrl)
 ```

--- a/src/account-link.ts
+++ b/src/account-link.ts
@@ -2,7 +2,8 @@ import prefixForNetwork from './prefix-for-network'
 
 export = function getAccountLink(address: string, network: string, customNetworkUrl?: string): string {
   if(customNetworkUrl?.length){
-    return `${customNetworkUrl}/address/${address}`;
+    let parsedUrl = new URL(`address/${address}`, customNetworkUrl)
+    return parsedUrl.toString();
   } else {
     const prefix = prefixForNetwork(network)
     return prefix !== null ? `https://${prefix}etherscan.io/address/${address}` : '';

--- a/src/account-link.ts
+++ b/src/account-link.ts
@@ -1,5 +1,6 @@
+import { addPathToUrl } from './helpers';
 import prefixForChain from './prefix-for-chain';
-import prefixForNetwork from './prefix-for-network'
+import prefixForNetwork from './prefix-for-network';
 
 export function createAccountLink(address: string, network: string): string {
   const prefix = prefixForNetwork(network)
@@ -12,6 +13,6 @@ export function createAccountLinkForChain(address: string, chainId: string): str
 }
 
 export function createCustomAccountLink(address: string, customNetworkUrl: string): string {
-    let parsedUrl = new URL(`address/${address}`, customNetworkUrl)
-    return parsedUrl.toString();
+    let parsedUrl = addPathToUrl(customNetworkUrl, 'address', address)
+    return parsedUrl;
 }

--- a/src/account-link.ts
+++ b/src/account-link.ts
@@ -13,6 +13,6 @@ export function createAccountLinkForChain(address: string, chainId: string): str
 }
 
 export function createCustomAccountLink(address: string, customNetworkUrl: string): string {
-    let parsedUrl = addPathToUrl(customNetworkUrl, 'address', address)
-    return parsedUrl;
+  const parsedUrl = addPathToUrl(customNetworkUrl, 'address', address)
+  return parsedUrl
 }

--- a/src/account-link.ts
+++ b/src/account-link.ts
@@ -1,6 +1,10 @@
 import prefixForNetwork from './prefix-for-network'
 
-export = function getAccountLink(address: string, network: string): string {
-  const prefix = prefixForNetwork(network)
-  return prefix !== null ? `https://${prefix}etherscan.io/address/${address}` : '';
+export = function getAccountLink(address: string, network: string, customNetworkUrl?: string): string {
+  if(customNetworkUrl?.length){
+    return `${customNetworkUrl}/address/${address}`;
+  } else {
+    const prefix = prefixForNetwork(network)
+    return prefix !== null ? `https://${prefix}etherscan.io/address/${address}` : '';
+  }
 }

--- a/src/account-link.ts
+++ b/src/account-link.ts
@@ -1,11 +1,11 @@
 import prefixForNetwork from './prefix-for-network'
 
-export = function getAccountLink(address: string, network: string, customNetworkUrl?: string): string {
-  if(customNetworkUrl?.length){
-    let parsedUrl = new URL(`address/${address}`, customNetworkUrl)
-    return parsedUrl.toString();
-  } else {
+export function getAccountLink(address: string, network: string, customNetworkUrl?: string): string {
     const prefix = prefixForNetwork(network)
     return prefix !== null ? `https://${prefix}etherscan.io/address/${address}` : '';
-  }
+}
+
+export function getCustomBlockExplorerAccountLink(address: string, customNetworkUrl: string): string {
+    let parsedUrl = new URL(`address/${address}`, customNetworkUrl)
+    return parsedUrl.toString();
 }

--- a/src/explorer-link.ts
+++ b/src/explorer-link.ts
@@ -3,9 +3,9 @@ import prefixForChain from './prefix-for-chain';
 import prefixForNetwork from './prefix-for-network';
      
 export function createCustomExplorerLink(hash: string, customNetworkUrl: string): string {
-  let parsedUrl = addPathToUrl(customNetworkUrl, 'tx', hash) 
-    return parsedUrl;
-  }
+  const parsedUrl = addPathToUrl(customNetworkUrl, 'tx', hash) 
+  return parsedUrl
+}
 
 export function createExplorerLink(hash: string, network: string): string {
   const prefix = prefixForNetwork(network)

--- a/src/explorer-link.ts
+++ b/src/explorer-link.ts
@@ -1,6 +1,10 @@
 import prefixForNetwork from './prefix-for-network'
 
-export = function getExplorerLink(hash: string, network: string): string {
-  const prefix = prefixForNetwork(network)
-  return prefix !== null ? `https://${prefix}etherscan.io/tx/${hash}`: '';
+export = function getExplorerLink(hash: string, network: string, customNetworkUrl?: string): string {
+  if(customNetworkUrl?.length){
+    return `${customNetworkUrl}/tx/${hash}`;
+  } else {
+    const prefix = prefixForNetwork(network)
+    return prefix !== null ? `https://${prefix}etherscan.io/tx/${hash}`: '';
+  }
 }

--- a/src/explorer-link.ts
+++ b/src/explorer-link.ts
@@ -1,9 +1,10 @@
+import { addPathToUrl } from './helpers';
 import prefixForChain from './prefix-for-chain';
-import prefixForNetwork from './prefix-for-network'
+import prefixForNetwork from './prefix-for-network';
      
-export function createCustomExplorerLink(hash: string, customNetworkUrl?: string): string {
-  let parsedUrl = new URL(`tx/${hash}`, customNetworkUrl)
-    return parsedUrl.toString();
+export function createCustomExplorerLink(hash: string, customNetworkUrl: string): string {
+  let parsedUrl = addPathToUrl(customNetworkUrl, 'tx', hash) 
+    return parsedUrl;
   }
 
 export function createExplorerLink(hash: string, network: string): string {

--- a/src/explorer-link.ts
+++ b/src/explorer-link.ts
@@ -2,7 +2,8 @@ import prefixForNetwork from './prefix-for-network'
 
 export = function getExplorerLink(hash: string, network: string, customNetworkUrl?: string): string {
   if(customNetworkUrl?.length){
-    return `${customNetworkUrl}/tx/${hash}`;
+    let parsedUrl = new URL(`tx/${hash}`, customNetworkUrl)
+    return parsedUrl.toString();
   } else {
     const prefix = prefixForNetwork(network)
     return prefix !== null ? `https://${prefix}etherscan.io/tx/${hash}`: '';

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,11 +1,11 @@
 export const addPathToUrl = (customNetworkUrl: string, linkType: string, suffixType?: string,) => {
-    const { username, password, protocol, host, pathname, search, hash } = new URL(customNetworkUrl)
+  const { username, password, protocol, host, pathname, search, hash } = new URL(customNetworkUrl)
 
-    const newPath = pathname.endsWith('/') ? `${pathname}${linkType}/${suffixType}` : `${pathname}/${linkType}/${suffixType}` 
-    
-    const auth = username ? `${username}:${password}` : ''
-    
-    let parsedUrl = new URL(`${protocol}//${auth}${host}${newPath}${search}${hash}`)
+  const newPath = pathname.endsWith('/') ? `${pathname}${linkType}/${suffixType}` : `${pathname}/${linkType}/${suffixType}` 
 
-    return parsedUrl.toString();
+  const auth = username ? `${username}:${password}` : ''
+
+  const parsedUrl = new URL(`${protocol}//${auth}${host}${newPath}${search}${hash}`)
+
+  return parsedUrl.toString()
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,0 +1,11 @@
+export const addPathToUrl = (customNetworkUrl: string, linkType: string, suffixType?: string,) => {
+    const { username, password, protocol, host, pathname, search, hash } = new URL(customNetworkUrl)
+
+    const newPath = pathname.endsWith('/') ? `${pathname}${linkType}/${suffixType}` : `${pathname}/${linkType}/${suffixType}` 
+    
+    const auth = username ? `${username}:${password}` : ''
+    
+    let parsedUrl = new URL(`${protocol}//${auth}${host}${newPath}${search}${hash}`)
+
+    return parsedUrl.toString();
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,10 @@
 import createExplorerLink from './explorer-link'
-import createAccountLink from './account-link'
+import {getAccountLink as createAccountLink, getCustomBlockExplorerAccountLink as createCustomAccountLink} from './account-link'
 import createTokenTrackerLink from './token-tracker-link'
 
 export = {
   createExplorerLink,
   createAccountLink,
+  createCustomAccountLink,
   createTokenTrackerLink,
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 
 import { createAccountLink, createAccountLinkForChain, createCustomAccountLink } from './account-link'
 import { createCustomExplorerLink, createExplorerLink, createExplorerLinkForChain } from './explorer-link'
-import { createTokenTrackerLink, createTokenTrackerLinkForChain } from './token-tracker-link'
+import { createTokenTrackerLink, createCustomTokenTrackerLink, createTokenTrackerLinkForChain } from './token-tracker-link'
 
 export = {
   createExplorerLink,
@@ -11,5 +11,6 @@ export = {
   createCustomAccountLink,
   createAccountLinkForChain,
   createTokenTrackerLink,
+  createCustomTokenTrackerLink,
   createTokenTrackerLinkForChain,
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
 import createExplorerLink from './explorer-link'
-import {getAccountLink as createAccountLink, getCustomBlockExplorerAccountLink as createCustomAccountLink} from './account-link'
+import { 
+  getAccountLink as createAccountLink, 
+  getCustomBlockExplorerAccountLink as createCustomAccountLink } from './account-link'
 import createTokenTrackerLink from './token-tracker-link'
 
 export = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 
-import { createExplorerLink, createCustomExplorerLink,  createExplorerLinkForChain } from './explorer-link'
 import { createAccountLink, createAccountLinkForChain, createCustomAccountLink } from './account-link'
+import { createCustomExplorerLink, createExplorerLink, createExplorerLinkForChain } from './explorer-link'
 import { createTokenTrackerLink, createTokenTrackerLinkForChain } from './token-tracker-link'
 
 export = {

--- a/src/token-tracker-link.ts
+++ b/src/token-tracker-link.ts
@@ -4,10 +4,16 @@ export = function getTokenTrackerLink(
   tokenAddress: string,
   network: string,
   holderAddress?: string,
+  customNetworkUrl?: string,
 ): string {
+  if(customNetworkUrl?.length){
+    return `${customNetworkUrl}/token/${tokenAddress}${ 
+      holderAddress ? `?a=${ holderAddress }`: ''}`;
+  } else {
   const prefix = prefixForNetwork(network)
   return prefix !== null ? 
       `https://${prefix}etherscan.io/token/${tokenAddress}${ 
         holderAddress ? `?a=${ holderAddress }` : '' }`
     : '';
+  }
 }

--- a/src/token-tracker-link.ts
+++ b/src/token-tracker-link.ts
@@ -9,7 +9,7 @@ export function createTokenTrackerLink(
   customNetworkUrl?: string,
 ): string {
   if(customNetworkUrl?.length){
-    let parsedUrl = addPathToUrl(customNetworkUrl, 'token', tokenAddress)
+    const parsedUrl = addPathToUrl(customNetworkUrl, 'token', tokenAddress)
     return parsedUrl;
   } else {
   const prefix = prefixForNetwork(network)

--- a/src/token-tracker-link.ts
+++ b/src/token-tracker-link.ts
@@ -1,5 +1,6 @@
+import { addPathToUrl } from './helpers';
 import prefixForChain from './prefix-for-chain';
-import prefixForNetwork from './prefix-for-network'
+import prefixForNetwork from './prefix-for-network';
 
 export function createTokenTrackerLink(
   tokenAddress: string,
@@ -8,8 +9,8 @@ export function createTokenTrackerLink(
   customNetworkUrl?: string,
 ): string {
   if(customNetworkUrl?.length){
-    let parsedUrl = new URL(`token/${tokenAddress}`,customNetworkUrl)
-    return parsedUrl.toString();
+    let parsedUrl = addPathToUrl(customNetworkUrl, 'token', tokenAddress)
+    return parsedUrl;
   } else {
   const prefix = prefixForNetwork(network)
   return prefix !== null ? 

--- a/src/token-tracker-link.ts
+++ b/src/token-tracker-link.ts
@@ -7,8 +7,7 @@ export = function getTokenTrackerLink(
   customNetworkUrl?: string,
 ): string {
   if(customNetworkUrl?.length){
-    return `${customNetworkUrl}/token/${tokenAddress}${ 
-      holderAddress ? `?a=${ holderAddress }`: ''}`;
+    return `${customNetworkUrl}/token/${tokenAddress}`;
   } else {
   const prefix = prefixForNetwork(network)
   return prefix !== null ? 

--- a/src/token-tracker-link.ts
+++ b/src/token-tracker-link.ts
@@ -6,19 +6,22 @@ export function createTokenTrackerLink(
   tokenAddress: string,
   network: string,
   holderAddress?: string,
-  customNetworkUrl?: string,
 ): string {
-  if (customNetworkUrl?.length){
-    const parsedUrl = addPathToUrl(customNetworkUrl, 'token', tokenAddress)
-    return parsedUrl
-  } else {
-    const prefix = prefixForNetwork(network)
-    return prefix !== null ? 
+  const prefix = prefixForNetwork(network)
+  return prefix !== null ? 
       `https://${prefix}etherscan.io/token/${tokenAddress}${ 
         holderAddress ? `?a=${ holderAddress }` : '' }`
-      : ''
-  }
+    : '';
 }
+
+export function createCustomTokenTrackerLink(
+  tokenAddress: string,
+  customNetworkUrl: string,
+): string {
+    const parsedUrl = addPathToUrl(customNetworkUrl, 'token', tokenAddress)
+    return parsedUrl;
+}
+
 
 export function createTokenTrackerLinkForChain(
   tokenAddress: string,

--- a/src/token-tracker-link.ts
+++ b/src/token-tracker-link.ts
@@ -8,15 +8,15 @@ export function createTokenTrackerLink(
   holderAddress?: string,
   customNetworkUrl?: string,
 ): string {
-  if(customNetworkUrl?.length){
+  if (customNetworkUrl?.length){
     const parsedUrl = addPathToUrl(customNetworkUrl, 'token', tokenAddress)
-    return parsedUrl;
+    return parsedUrl
   } else {
-  const prefix = prefixForNetwork(network)
-  return prefix !== null ? 
+    const prefix = prefixForNetwork(network)
+    return prefix !== null ? 
       `https://${prefix}etherscan.io/token/${tokenAddress}${ 
         holderAddress ? `?a=${ holderAddress }` : '' }`
-    : '';
+      : ''
   }
 }
 

--- a/src/token-tracker-link.ts
+++ b/src/token-tracker-link.ts
@@ -7,7 +7,8 @@ export = function getTokenTrackerLink(
   customNetworkUrl?: string,
 ): string {
   if(customNetworkUrl?.length){
-    return `${customNetworkUrl}/token/${tokenAddress}`;
+    let parsedUrl = new URL(`token/${tokenAddress}`,customNetworkUrl)
+    return parsedUrl.toString();
   } else {
   const prefix = prefixForNetwork(network)
   return prefix !== null ? 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -83,7 +83,7 @@ describe('token-tracker-link', function () {
   })
 
   it('should handle customNetwork url correctly', function () {
-    const result = createTokenTrackerLink('foo', '3', '0xabc', 'https://data-seed-prebsc-1-s1.binance.org:8545')
-    assert.strictEqual(result, 'https://data-seed-prebsc-1-s1.binance.org:8545/token/foo?a=0xabc', 'should return binance testnet token url')
+    const result = createTokenTrackerLink('foo', '3', '0xabc', 'https://data-seed-prebsc-1-s1.binance.org:8545/')
+    assert.strictEqual(result, 'https://data-seed-prebsc-1-s1.binance.org:8545/token/foo', 'should return binance testnet token url')
   })
 })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,6 +1,7 @@
 const assert = require('assert')
 const {
   createAccountLink,
+  createCustomAccountLink,
   createExplorerLink,
   createTokenTrackerLink,
 } = require('../dist')
@@ -23,7 +24,7 @@ describe('account-link', function () {
   })
 
   it('should handle customNetwork url correctly', function () {
-    const result = createAccountLink('foo', '3234', 'https://data-seed-prebsc-1-s1.binance.org:8545')
+    const result = createCustomAccountLink('foo', 'https://data-seed-prebsc-1-s1.binance.org:8545')
     assert.strictEqual(result, 'https://data-seed-prebsc-1-s1.binance.org:8545/address/foo', 'should return binance testnet address url')
   })
 })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -21,6 +21,11 @@ describe('account-link', function () {
     const result = createAccountLink('foo', '3234')
     assert.strictEqual(result, '', 'should return an empty string')
   })
+
+  it('should handle customNetwork url correctly', function () {
+    const result = createAccountLink('foo', '3234', 'https://data-seed-prebsc-1-s1.binance.org:8545')
+    assert.strictEqual(result, 'https://data-seed-prebsc-1-s1.binance.org:8545/address/foo', 'should return binance testnet address url')
+  })
 })
 
 // `https://${prefix}etherscan.io/tx/${hash}`
@@ -38,6 +43,11 @@ describe('explorer-link', function () {
   it('should have null as a prefix', function () {
     const result = createExplorerLink('foo', '10')
     assert.strictEqual(result, '', 'should return an empty string')
+  })
+
+  it('should handle customNetwork url correctly', function () {
+    const result = createExplorerLink('foo', '3', 'https://data-seed-prebsc-1-s1.binance.org:8545')
+    assert.strictEqual(result, 'https://data-seed-prebsc-1-s1.binance.org:8545/tx/foo', 'should return binance testnet transaction url')
   })
 })
 
@@ -70,5 +80,10 @@ describe('token-tracker-link', function () {
   it('should null has a prefix', function () {
     const result = createTokenTrackerLink('foo', '3654', '0xabc')
     assert.strictEqual(result, '', 'should return an empty string')
+  })
+
+  it('should handle customNetwork url correctly', function () {
+    const result = createTokenTrackerLink('foo', '3', '0xabc', 'https://data-seed-prebsc-1-s1.binance.org:8545')
+    assert.strictEqual(result, 'https://data-seed-prebsc-1-s1.binance.org:8545/token/foo?a=0xabc', 'should return binance testnet token url')
   })
 })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -5,6 +5,7 @@ const {
   createExplorerLink,
   createTokenTrackerLink,
   createExplorerLinkForChain,
+  createCustomExplorerLink,
   createAccountLinkForChain,
   createTokenTrackerLinkForChain
 } = require('../dist')
@@ -88,7 +89,7 @@ describe('explorer-link', function () {
   })
 
   it('should handle customNetwork url correctly', function () {
-    const result = createExplorerLink('foo', '3', 'https://data-seed-prebsc-1-s1.binance.org:8545')
+    const result = createCustomExplorerLink('foo', 'https://data-seed-prebsc-1-s1.binance.org:8545')
     assert.strictEqual(result, 'https://data-seed-prebsc-1-s1.binance.org:8545/tx/foo', 'should return binance testnet transaction url')
   })
 })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -3,9 +3,10 @@ const {
   createAccountLink,
   createCustomAccountLink,
   createExplorerLink,
-  createTokenTrackerLink,
-  createExplorerLinkForChain,
   createCustomExplorerLink,
+  createTokenTrackerLink,
+  createCustomTokenTrackerLink,
+  createExplorerLinkForChain,
   createAccountLinkForChain,
   createTokenTrackerLinkForChain
 } = require('../dist')
@@ -87,6 +88,11 @@ describe('explorer-link', function () {
       assert.strictEqual(result, '', 'should return an empty string')
     })
   })
+  
+  it('should handle customNetwork url correctly', function () {
+    const result = createExplorerLink('foo', '3',)
+    assert.strictEqual(result, 'https://ropsten.etherscan.io/tx/foo', 'should handle ropsten')
+  })
 
   it('should handle customNetwork url correctly', function () {
     const result = createCustomExplorerLink('foo', 'https://data-seed-prebsc-1-s1.binance.org:8545')
@@ -152,10 +158,10 @@ describe('token-tracker-link', function () {
       const result = createTokenTrackerLinkForChain('foo', '0xe46', '0xabc')
       assert.strictEqual(result, '', 'should return an empty string')
     })
-  })
 
-  it('should handle customNetwork url correctly', function () {
-    const result = createTokenTrackerLink('foo', '3', '0xabc', 'https://data-seed-prebsc-1-s1.binance.org:8545/')
-    assert.strictEqual(result, 'https://data-seed-prebsc-1-s1.binance.org:8545/token/foo', 'should return binance testnet token url')
+    it('should handle customNetwork url correctly', function () {
+      const result = createCustomTokenTrackerLink('foo', 'https://data-seed-prebsc-1-s1.binance.org:8545/')
+      assert.strictEqual(result, 'https://data-seed-prebsc-1-s1.binance.org:8545/token/foo', 'should return binance testnet token url')
+    })
   })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "module": "CommonJS",
     "sourceMap": true,
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "esModuleInterop": true,
     "typeRoots": [
       "./node_modules/@types"


### PR DESCRIPTION
This should allow for the ability to generate urls for custom networks based upon [EIP 3091](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-3091.md).

Still a WIP. Tried several other ways to do this but decided on this. Would love to know ya'lls thoughts 🙂!! Any better ideas to on building this out? @Gudahtt  @rekmarks @danfinlay @darkwing  