### PR TITLE
add forChain corollaries to link builder methods

### DIFF
--- a/src/account-link.ts
+++ b/src/account-link.ts
@@ -1,6 +1,12 @@
+import prefixForChain from './prefix-for-chain';
 import prefixForNetwork from './prefix-for-network'
 
-export = function getAccountLink(address: string, network: string): string {
+export function createAccountLink(address: string, network: string): string {
   const prefix = prefixForNetwork(network)
+  return prefix !== null ? `https://${prefix}etherscan.io/address/${address}` : '';
+}
+
+export function createAccountLinkForChain(address: string, chainId: string): string {
+  const prefix = prefixForChain(chainId)
   return prefix !== null ? `https://${prefix}etherscan.io/address/${address}` : '';
 }

--- a/src/explorer-link.ts
+++ b/src/explorer-link.ts
@@ -1,6 +1,12 @@
+import prefixForChain from './prefix-for-chain';
 import prefixForNetwork from './prefix-for-network'
 
-export = function getExplorerLink(hash: string, network: string): string {
+export function createExplorerLink(hash: string, network: string): string {
   const prefix = prefixForNetwork(network)
+  return prefix !== null ? `https://${prefix}etherscan.io/tx/${hash}`: '';
+}
+
+export function createExplorerLinkForChain(hash: string, chainId: string): string {
+  const prefix = prefixForChain(chainId)
   return prefix !== null ? `https://${prefix}etherscan.io/tx/${hash}`: '';
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,12 @@
-import createExplorerLink from './explorer-link'
-import createAccountLink from './account-link'
-import createTokenTrackerLink from './token-tracker-link'
+import { createExplorerLink, createExplorerLinkForChain } from './explorer-link'
+import { createAccountLink, createAccountLinkForChain } from './account-link'
+import { createTokenTrackerLink, createTokenTrackerLinkForChain } from './token-tracker-link'
 
 export = {
   createExplorerLink,
+  createExplorerLinkForChain,
   createAccountLink,
+  createAccountLinkForChain,
   createTokenTrackerLink,
+  createTokenTrackerLinkForChain,
 }

--- a/src/prefix-for-chain.ts
+++ b/src/prefix-for-chain.ts
@@ -1,0 +1,23 @@
+export = function getPrefixForChain(chainId: string): string | null {
+  let prefix;
+  switch (chainId) {
+    case '0x1': // main net
+      prefix = ''
+      break
+    case '0x3': // ropsten test net
+      prefix = 'ropsten.'
+      break
+    case '0x4': // rinkeby test net
+      prefix = 'rinkeby.'
+      break
+    case '0x5': // goerli test net
+      prefix = 'goerli.'
+      break
+    case '0x2a': // kovan test net
+      prefix = 'kovan.'
+      break
+    default:
+      prefix = null
+  }
+  return prefix
+}

--- a/src/token-tracker-link.ts
+++ b/src/token-tracker-link.ts
@@ -1,11 +1,24 @@
+import prefixForChain from './prefix-for-chain';
 import prefixForNetwork from './prefix-for-network'
 
-export = function getTokenTrackerLink(
+export function createTokenTrackerLink(
   tokenAddress: string,
   network: string,
   holderAddress?: string,
 ): string {
   const prefix = prefixForNetwork(network)
+  return prefix !== null ? 
+      `https://${prefix}etherscan.io/token/${tokenAddress}${ 
+        holderAddress ? `?a=${ holderAddress }` : '' }`
+    : '';
+}
+
+export function createTokenTrackerLinkForChain(
+  tokenAddress: string,
+  chainId: string,
+  holderAddress?: string,
+): string {
+  const prefix = prefixForChain(chainId)
   return prefix !== null ? 
       `https://${prefix}etherscan.io/token/${tokenAddress}${ 
         holderAddress ? `?a=${ holderAddress }` : '' }`

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -3,41 +3,82 @@ const {
   createAccountLink,
   createExplorerLink,
   createTokenTrackerLink,
+  createExplorerLinkForChain,
+  createAccountLinkForChain,
+  createTokenTrackerLinkForChain
 } = require('../dist')
 
 // `https://${prefix}etherscan.io/address/${address}`
 describe('account-link', function () {
-  it('should handle mainnet correctly', function () {
-    const result = createAccountLink('foo', '1')
-    assert.strictEqual(result, 'https://etherscan.io/address/foo', 'should handle mainnet')
+  describe('by networkId', function() {
+    it('should handle mainnet correctly', function () {
+      const result = createAccountLink('foo', '1')
+      assert.strictEqual(result, 'https://etherscan.io/address/foo', 'should handle mainnet')
+    })
+  
+    it('should handle ropsten correctly', function () {
+      const result = createAccountLink('foo', '3')
+      assert.strictEqual(result, 'https://ropsten.etherscan.io/address/foo', 'should handle ropsten')
+    })
+  
+    it('should have null as a prefix', function () {
+      const result = createAccountLink('foo', '3234')
+      assert.strictEqual(result, '', 'should return an empty string')
+    })
   })
 
-  it('should handle ropsten correctly', function () {
-    const result = createAccountLink('foo', '3')
-    assert.strictEqual(result, 'https://ropsten.etherscan.io/address/foo', 'should handle ropsten')
-  })
-
-  it('should have null as a prefix', function () {
-    const result = createAccountLink('foo', '3234')
-    assert.strictEqual(result, '', 'should return an empty string')
+  describe('by chainId', function() {
+    it('should handle mainnet correctly', function () {
+      const result = createAccountLinkForChain('foo', '0x1')
+      assert.strictEqual(result, 'https://etherscan.io/address/foo', 'should handle mainnet')
+    })
+  
+    it('should handle ropsten correctly', function () {
+      const result = createAccountLinkForChain('foo', '0x3')
+      assert.strictEqual(result, 'https://ropsten.etherscan.io/address/foo', 'should handle ropsten')
+    })
+  
+    it('should have null as a prefix', function () {
+      const result = createAccountLinkForChain('foo', '0xca2')
+      assert.strictEqual(result, '', 'should return an empty string')
+    })
   })
 })
 
 // `https://${prefix}etherscan.io/tx/${hash}`
 describe('explorer-link', function () {
-  it('should handle mainnet correctly', function () {
-    const result = createExplorerLink('foo', '1')
-    assert.strictEqual(result, 'https://etherscan.io/tx/foo', 'should handle mainnet')
+  describe('by networkId', function () {
+    it('should handle mainnet correctly', function () {
+      const result = createExplorerLink('foo', '1')
+      assert.strictEqual(result, 'https://etherscan.io/tx/foo', 'should handle mainnet')
+    })
+  
+    it('should handle ropsten correctly', function () {
+      const result = createExplorerLink('foo', '3')
+      assert.strictEqual(result, 'https://ropsten.etherscan.io/tx/foo', 'should handle ropsten')
+    })
+  
+    it('should have null as a prefix', function () {
+      const result = createExplorerLink('foo', '10')
+      assert.strictEqual(result, '', 'should return an empty string')
+    })
   })
 
-  it('should handle ropsten correctly', function () {
-    const result = createExplorerLink('foo', '3')
-    assert.strictEqual(result, 'https://ropsten.etherscan.io/tx/foo', 'should handle ropsten')
-  })
-
-  it('should have null as a prefix', function () {
-    const result = createExplorerLink('foo', '10')
-    assert.strictEqual(result, '', 'should return an empty string')
+  describe('by networkId', function () {
+    it('should handle mainnet correctly', function () {
+      const result = createExplorerLinkForChain('foo', '0x1')
+      assert.strictEqual(result, 'https://etherscan.io/tx/foo', 'should handle mainnet')
+    })
+  
+    it('should handle ropsten correctly', function () {
+      const result = createExplorerLinkForChain('foo', '0x3')
+      assert.strictEqual(result, 'https://ropsten.etherscan.io/tx/foo', 'should handle ropsten')
+    })
+  
+    it('should have null as a prefix', function () {
+      const result = createExplorerLinkForChain('foo', '0xa')
+      assert.strictEqual(result, '', 'should return an empty string')
+    })
   })
 })
 
@@ -47,28 +88,57 @@ describe('explorer-link', function () {
  *  }`
  */
 describe('token-tracker-link', function () {
-  it('should handle mainnet correctly (no account)', function () {
-    const result = createTokenTrackerLink('foo', '1')
-    assert.strictEqual(result, 'https://etherscan.io/token/foo', 'should handle mainnet')
+  describe('by networkId', function () {
+    it('should handle mainnet correctly (no account)', function () {
+      const result = createTokenTrackerLink('foo', '1')
+      assert.strictEqual(result, 'https://etherscan.io/token/foo', 'should handle mainnet')
+    })
+  
+    it('should handle ropsten correctly (no account)', function () {
+      const result = createTokenTrackerLink('foo', '3')
+      assert.strictEqual(result, 'https://ropsten.etherscan.io/token/foo', 'should handle ropsten')
+    })
+  
+    it('should handle mainnet correctly (account)', function () {
+      const result = createTokenTrackerLink('foo', '1', '0xabc')
+      assert.strictEqual(result, 'https://etherscan.io/token/foo?a=0xabc', 'should handle mainnet')
+    })
+  
+    it('should handle ropsten correctly (account)', function () {
+      const result = createTokenTrackerLink('foo', '3', '0xabc')
+      assert.strictEqual(result, 'https://ropsten.etherscan.io/token/foo?a=0xabc', 'should handle ropsten')
+    })
+  
+    it('should null has a prefix', function () {
+      const result = createTokenTrackerLink('foo', '3654', '0xabc')
+      assert.strictEqual(result, '', 'should return an empty string')
+    })
   })
 
-  it('should handle ropsten correctly (no account)', function () {
-    const result = createTokenTrackerLink('foo', '3')
-    assert.strictEqual(result, 'https://ropsten.etherscan.io/token/foo', 'should handle ropsten')
-  })
-
-  it('should handle mainnet correctly (account)', function () {
-    const result = createTokenTrackerLink('foo', '1', '0xabc')
-    assert.strictEqual(result, 'https://etherscan.io/token/foo?a=0xabc', 'should handle mainnet')
-  })
-
-  it('should handle ropsten correctly (account)', function () {
-    const result = createTokenTrackerLink('foo', '3', '0xabc')
-    assert.strictEqual(result, 'https://ropsten.etherscan.io/token/foo?a=0xabc', 'should handle ropsten')
-  })
-
-  it('should null has a prefix', function () {
-    const result = createTokenTrackerLink('foo', '3654', '0xabc')
-    assert.strictEqual(result, '', 'should return an empty string')
+  describe('by chainId', function () {
+    it('should handle mainnet correctly (no account)', function () {
+      const result = createTokenTrackerLinkForChain('foo', '0x1')
+      assert.strictEqual(result, 'https://etherscan.io/token/foo', 'should handle mainnet')
+    })
+  
+    it('should handle ropsten correctly (no account)', function () {
+      const result = createTokenTrackerLinkForChain('foo', '0x3')
+      assert.strictEqual(result, 'https://ropsten.etherscan.io/token/foo', 'should handle ropsten')
+    })
+  
+    it('should handle mainnet correctly (account)', function () {
+      const result = createTokenTrackerLinkForChain('foo', '0x1', '0xabc')
+      assert.strictEqual(result, 'https://etherscan.io/token/foo?a=0xabc', 'should handle mainnet')
+    })
+  
+    it('should handle ropsten correctly (account)', function () {
+      const result = createTokenTrackerLinkForChain('foo', '0x3', '0xabc')
+      assert.strictEqual(result, 'https://ropsten.etherscan.io/token/foo?a=0xabc', 'should handle ropsten')
+    })
+  
+    it('should null has a prefix', function () {
+      const result = createTokenTrackerLinkForChain('foo', '0xe46', '0xabc')
+      assert.strictEqual(result, '', 'should return an empty string')
+    })
   })
 })


### PR DESCRIPTION
In an effort to not introduce a breaking change in this package, this PR adds new method corollaries for building tracker links with `chainId` instead of `networkId`. 