### PR TITLE
1.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.4.2] - 2021-03-05
 
-### Changed
+### Added
 
 - Add forChain corollaries for all methods for URL generation by chainId ([#32](https://github.com/MetaMask/etherscan-link/pull/32))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.2] - 2021-03-05
+
+### Changed
+
+- Add forChain corollaries for all methods for URL generation by chainId ([#32](https://github.com/MetaMask/etherscan-link/pull/32))
+
 ## [1.4.1] - 2021-02-16
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -10,14 +10,18 @@
 const etherscanLink = require('@metamask/etherscan-link')
 
 const networkId = '1'
+const chainId = '0x1'
 const account = '0xFDEa65C8e26263F6d9A1B5de9555D2931A33b825'
 const accountLink = etherscanLink.createAccountLink(account, networkId)
+const accountLinkForChain = etherscanLink.createAccountLinkForChain(account, chainId)
 
 const hash = '0xa7540793de6b6ca7d3c948a8cc0a163bf107f5535a69353162ea9dec7ee7beca'
 const txLink = etherscanLink.createExplorerLink(hash, networkId)
+const txtLinkForChain = etherscanLink.createExplorerLinkForChain(hash, chainId)
 
 const token = '0xdac17f958d2ee523a2206206994597c13d831ec7'
 const tokenTrackerLink = etherscanLink.createTokenTrackerLink(token, networkId)
 // You can also track token balances by account
 const accountTokenTrackerLink = etherscanLink.createTokenTrackerLink(token, networkId, account)
+const accountTokenTrackerLinkForChain = etherscanLink.createTokenTrackerLinkForChain(token, chainId, account)
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/etherscan-link",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "A library for generating etherscan links.",
   "main": "dist/index.js",
   "publishConfig": {


### PR DESCRIPTION
Opted for non-breaking because all of the original methods exist and behave exactly the same. If we can land #31 as well before release we can make a call on whether we update this to 1.5.0