### PR TITLE
Add CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,92 @@
+version: 2.1
+
+executors:
+  node:
+    parameters:
+        node_version:
+          type: integer
+          default: 10
+    docker:
+      - image: circleci/node:<< parameters.node_version >>
+
+workflows:
+  build-test:
+    jobs:
+      - prep-deps:
+          name: prep-deps-<< matrix.node_version >>
+          matrix:
+            parameters:
+              node_version: [10, 12, 14]
+      - test-lint:
+          requires:
+            - prep-deps-10
+      - test-unit:
+          matrix:
+            parameters:
+              node_version: [10, 12, 14]
+          requires:
+            - prep-deps-<< matrix.node_version >>
+      - all-tests-pass:
+          requires:
+            - test-lint
+            - test-unit
+
+jobs:
+  prep-deps:
+    parameters:
+      node_version:
+        type: integer
+    executor:
+      name: node
+      node_version: << parameters.node_version >>
+    steps:
+      - checkout
+      - run:
+          name: Install deps
+          command: |
+            .circleci/scripts/deps-install.sh
+      - run:
+          name: Collect yarn install HAR logs
+          command: |
+            .circleci/scripts/collect-har-artifact.sh
+      - persist_to_workspace:
+          root: .
+          paths:
+          - node_modules
+          - build-artifacts
+
+  test-lint:
+    executor:
+      name: node
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: Build
+          command: yarn build
+      - run:
+          name: Lint
+          command: yarn lint
+
+  test-unit:
+    parameters:
+      node_version:
+        type: integer
+    executor:
+      name: node
+      node_version: << parameters.node_version >>
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: Unit tests
+          command: yarn test
+
+  all-tests-pass:
+    executor: node
+    steps:
+      - run:
+          name: All tests passed
+          command: echo 'Great success'

--- a/.circleci/scripts/collect-har-artifact.sh
+++ b/.circleci/scripts/collect-har-artifact.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -x
+set -e
+set -u
+set -o pipefail
+
+mkdir -p build-artifacts/yarn-install-har
+mv ./*.har build-artifacts/yarn-install-har/

--- a/.circleci/scripts/deps-install.sh
+++ b/.circleci/scripts/deps-install.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -x
+set -e
+set -u
+set -o pipefail
+
+yarn --frozen-lockfile --har


### PR DESCRIPTION
This CircleCI config is copied from `eth-json-rpc-filters`, which was recently updated to test on all Node.js LTS versions. Aside from the test matrix, it follows the typical conventions present in all of our library CircleCI configs (`deps-install.sh` script and HAR logs, separate test and lint jobs, a final `all-tests-pass` job to use as the required status check, etc.).

Fixes #4