### PR TITLE
Add minimum Node.js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,5 +33,8 @@
   "devDependencies": {
     "mocha": "^7.1.1",
     "typescript": "^4.0.5"
+  },
+  "engines": {
+    "node": ">=10"
   }
 }


### PR DESCRIPTION
The minimum Node.js version is now set to v10, which is the oldest currently supported Node.js LTS version.