### PR TITLE
v2.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0] - 2021-03-11
+
+### Added
+
+- Add support for custom block explorer URL generation ([#31](https://github.com/MetaMask/etherscan-link/pull/31))
+
+### Changed
+
+- [**BREAKING**]: Drop support for Node.js versions below v10 ([#38](https://github.com/MetaMask/etherscan-link/pull/38))
+
 ## [1.5.0] - 2021-03-08
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/etherscan-link",
-  "version": "1.5.0",
+  "version": "2.0.0",
   "description": "A library for generating etherscan links.",
   "main": "dist/index.js",
   "publishConfig": {


### PR DESCRIPTION
This is a breaking release because it drops support for Node.js versions below v10. It also includes the addition of functions for generating custom block explorer URLs.