### PR TITLE
lift all explorer link generation logic to etherscan-link repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ const customtTokenTrackerLink = etherscanLink.createCustomTokenTrackerLink(token
 const customAccountLink = etherscanLink.createCustomAccountLink(account, customNetworkUrl)
 
 const customExplorerLink = etherscanLink.createCustomExplorerLink(hash, customNetworkUrl)
+
+// Generate custom or native block explorer link based on rcpPrefs
+const blockExplorerLink = etherscanLink.getBlockExplorerUrlForTx(transaction, rcpPrefs)
 ```
 
 ## Running tests

--- a/src/explorer-link.ts
+++ b/src/explorer-link.ts
@@ -2,6 +2,16 @@ import { addPathToUrl } from './helpers';
 import prefixForChain from './prefix-for-chain';
 import prefixForNetwork from './prefix-for-network';
 
+interface TransactionInterface {
+  hash: string;
+  chainId: string;
+  metamaskNetworkId: string;
+}
+
+interface RpcPrefsInterface {
+  blockExplorerUrl?: string;
+}
+
 export function createCustomExplorerLink(hash: string, customNetworkUrl: string): string {
   const parsedUrl = addPathToUrl(customNetworkUrl, 'tx', hash);
   return parsedUrl;
@@ -16,4 +26,14 @@ export function createExplorerLink(hash: string, network: string): string {
 export function createExplorerLinkForChain(hash: string, chainId: string): string {
   const prefix = prefixForChain(chainId);
   return prefix === null ? '' : `https://${prefix}etherscan.io/tx/${hash}`;
+}
+
+export function getBlockExplorerUrlForTx(transaction: TransactionInterface, rpcPrefs: RpcPrefsInterface = {}) {
+  if (rpcPrefs.blockExplorerUrl) {
+    return createCustomExplorerLink(transaction.hash, rpcPrefs.blockExplorerUrl);
+  }
+  if (transaction.chainId) {
+    return createExplorerLinkForChain(transaction.hash, transaction.chainId);
+  }
+  return createExplorerLink(transaction.hash, transaction.metamaskNetworkId);
 }


### PR DESCRIPTION
Proposal to lift the utility explorer link generation method, created in this [PR](https://github.com/MetaMask/metamask-extension/pull/10587/files), which makes use of etherscan-link methods, into this repo. 

I will pull tests over and open a PR to remove the corresponding method in the metamask-extension repo if folks think this is a good move.