### PR TITLE
Lift getAccountLink / Create getTokenTracker / Add tests for getBlockExplorerUrlForTx

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,13 @@ const customAccountLink = etherscanLink.createCustomAccountLink(account, customN
 const customExplorerLink = etherscanLink.createCustomExplorerLink(hash, customNetworkUrl)
 
 // Generate custom or native block explorer link based on rcpPrefs
-const blockExplorerLink = etherscanLink.getBlockExplorerUrlForTx(transaction, rcpPrefs)
+const blockExplorerLink = etherscanLink.getBlockExplorerLink(transaction, rcpPrefs)
+
+// Generate account link for custom or native network 
+const getAccountLink = etherscanLink.getAccountLink(address, chainId, rpcPrefs, networkId)
+
+// Generate token tracker link for custom or native network 
+const tokenTrackerLink = etherscanLink.getTokenTrackerLink(tokenAddress, chainId, networkId, holderAddress, rpcPrefs)
 ```
 
 ## Running tests

--- a/src/account-link.ts
+++ b/src/account-link.ts
@@ -2,8 +2,12 @@ import { addPathToUrl } from './helpers';
 import prefixForChain from './prefix-for-chain';
 import prefixForNetwork from './prefix-for-network';
 
-export function createAccountLink(address: string, network: string): string {
-  const prefix = prefixForNetwork(network);
+interface RpcPrefsInterface {
+  blockExplorerUrl?: string;
+}
+
+export function createAccountLink(address: string, networkId: string): string {
+  const prefix = prefixForNetwork(networkId);
   return prefix === null ? '' : `https://${prefix}etherscan.io/address/${address}`;
 }
 
@@ -15,4 +19,14 @@ export function createAccountLinkForChain(address: string, chainId: string): str
 export function createCustomAccountLink(address: string, customNetworkUrl: string): string {
   const parsedUrl = addPathToUrl(customNetworkUrl, 'address', address);
   return parsedUrl;
+}
+
+export function getAccountLink(address: string, chainId: string, rpcPrefs: RpcPrefsInterface = {}, networkId = '') {
+  if (rpcPrefs.blockExplorerUrl) {
+    return createCustomAccountLink(address, rpcPrefs.blockExplorerUrl);
+  }
+  if (networkId) {
+    return createAccountLink(address, networkId);
+  }
+  return createAccountLinkForChain(address, chainId);
 }

--- a/src/explorer-link.ts
+++ b/src/explorer-link.ts
@@ -2,12 +2,12 @@ import { addPathToUrl } from './helpers';
 import prefixForChain from './prefix-for-chain';
 import prefixForNetwork from './prefix-for-network';
 
+// TODO improve type safety / discriminating unions (this may require a discriminant property)
 interface TransactionInterface {
   hash: string;
-  chainId?: string;
+  chainId: string;
   metamaskNetworkId: string;
 }
-
 interface RpcPrefsInterface {
   blockExplorerUrl?: string;
 }
@@ -28,7 +28,7 @@ export function createExplorerLinkForChain(hash: string, chainId: string): strin
   return prefix === null ? '' : `https://${prefix}etherscan.io/tx/${hash}`;
 }
 
-export function getBlockExplorerUrlForTx(transaction: TransactionInterface, rpcPrefs: RpcPrefsInterface = {}) {
+export function getBlockExplorerLink(transaction: TransactionInterface, rpcPrefs: RpcPrefsInterface = {}) {
   if (rpcPrefs.blockExplorerUrl) {
     return createCustomExplorerLink(transaction.hash, rpcPrefs.blockExplorerUrl);
   }

--- a/src/explorer-link.ts
+++ b/src/explorer-link.ts
@@ -4,7 +4,7 @@ import prefixForNetwork from './prefix-for-network';
 
 interface TransactionInterface {
   hash: string;
-  chainId: string;
+  chainId?: string;
   metamaskNetworkId: string;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 
 import { createAccountLink, createAccountLinkForChain, createCustomAccountLink, getAccountLink } from './account-link';
 import { createCustomExplorerLink, createExplorerLink, createExplorerLinkForChain, getBlockExplorerUrlForTx } from './explorer-link';
-import { createTokenTrackerLink, createCustomTokenTrackerLink, createTokenTrackerLinkForChain } from './token-tracker-link';
+import { createTokenTrackerLink, createCustomTokenTrackerLink, createTokenTrackerLinkForChain, getTokenTracker } from './token-tracker-link';
 
 export = {
   createExplorerLink,
@@ -15,4 +15,5 @@ export = {
   createTokenTrackerLinkForChain,
   getBlockExplorerUrlForTx,
   getAccountLink,
+  getTokenTracker,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 
-import { createAccountLink, createAccountLinkForChain, createCustomAccountLink } from './account-link';
+import { createAccountLink, createAccountLinkForChain, createCustomAccountLink, getAccountLink } from './account-link';
 import { createCustomExplorerLink, createExplorerLink, createExplorerLinkForChain, getBlockExplorerUrlForTx } from './explorer-link';
 import { createTokenTrackerLink, createCustomTokenTrackerLink, createTokenTrackerLinkForChain } from './token-tracker-link';
 
@@ -14,4 +14,5 @@ export = {
   createCustomTokenTrackerLink,
   createTokenTrackerLinkForChain,
   getBlockExplorerUrlForTx,
+  getAccountLink,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 
 import { createAccountLink, createAccountLinkForChain, createCustomAccountLink, getAccountLink } from './account-link';
-import { createCustomExplorerLink, createExplorerLink, createExplorerLinkForChain, getBlockExplorerUrlForTx } from './explorer-link';
-import { createTokenTrackerLink, createCustomTokenTrackerLink, createTokenTrackerLinkForChain, getTokenTracker } from './token-tracker-link';
+import { createCustomExplorerLink, createExplorerLink, createExplorerLinkForChain, getBlockExplorerLink } from './explorer-link';
+import { createTokenTrackerLink, createCustomTokenTrackerLink, createTokenTrackerLinkForChain, getTokenTrackerLink } from './token-tracker-link';
 
 export = {
   createExplorerLink,
@@ -13,7 +13,7 @@ export = {
   createTokenTrackerLink,
   createCustomTokenTrackerLink,
   createTokenTrackerLinkForChain,
-  getBlockExplorerUrlForTx,
+  getBlockExplorerLink,
   getAccountLink,
-  getTokenTracker,
+  getTokenTrackerLink,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 
 import { createAccountLink, createAccountLinkForChain, createCustomAccountLink } from './account-link';
-import { createCustomExplorerLink, createExplorerLink, createExplorerLinkForChain } from './explorer-link';
+import { createCustomExplorerLink, createExplorerLink, createExplorerLinkForChain, getBlockExplorerUrlForTx } from './explorer-link';
 import { createTokenTrackerLink, createCustomTokenTrackerLink, createTokenTrackerLinkForChain } from './token-tracker-link';
 
 export = {
@@ -13,4 +13,5 @@ export = {
   createTokenTrackerLink,
   createCustomTokenTrackerLink,
   createTokenTrackerLinkForChain,
+  getBlockExplorerUrlForTx,
 };

--- a/src/prefix-for-network.ts
+++ b/src/prefix-for-network.ts
@@ -1,6 +1,6 @@
-export = function getPrefixForNetwork(network: string): string | null {
+export = function getPrefixForNetwork(networkId: string): string | null {
   // eslint-disable-next-line radix
-  const net = parseInt(network);
+  const net = parseInt(networkId);
   let prefix;
 
   switch (net) {

--- a/src/token-tracker-link.ts
+++ b/src/token-tracker-link.ts
@@ -36,7 +36,7 @@ export function createTokenTrackerLinkForChain(
       holderAddress ? `?a=${holderAddress}` : ''}`;
 }
 
-export function getTokenTracker(tokenAddress: string, chainId: string, networkId: string, holderAddress?: string, rpcPrefs: RpcPrefsInterface = {}) {
+export function getTokenTrackerLink(tokenAddress: string, chainId: string, networkId: string, holderAddress?: string, rpcPrefs: RpcPrefsInterface = {}) {
   if (rpcPrefs.blockExplorerUrl) {
     return createCustomTokenTrackerLink(tokenAddress, rpcPrefs.blockExplorerUrl);
   }

--- a/src/token-tracker-link.ts
+++ b/src/token-tracker-link.ts
@@ -2,12 +2,16 @@ import { addPathToUrl } from './helpers';
 import prefixForChain from './prefix-for-chain';
 import prefixForNetwork from './prefix-for-network';
 
+interface RpcPrefsInterface {
+  blockExplorerUrl?: string;
+}
+
 export function createTokenTrackerLink(
   tokenAddress: string,
-  network: string,
+  networkId: string,
   holderAddress?: string,
 ): string {
-  const prefix = prefixForNetwork(network);
+  const prefix = prefixForNetwork(networkId);
   return prefix === null ? '' :
     `https://${prefix}etherscan.io/token/${tokenAddress}${
       holderAddress ? `?a=${holderAddress}` : ''}`;
@@ -30,4 +34,14 @@ export function createTokenTrackerLinkForChain(
   return prefix === null ? '' :
     `https://${prefix}etherscan.io/token/${tokenAddress}${
       holderAddress ? `?a=${holderAddress}` : ''}`;
+}
+
+export function getTokenTracker(tokenAddress: string, chainId: string, networkId: string, holderAddress?: string, rpcPrefs: RpcPrefsInterface = {}) {
+  if (rpcPrefs.blockExplorerUrl) {
+    return createCustomTokenTrackerLink(tokenAddress, rpcPrefs.blockExplorerUrl);
+  }
+  if (networkId) {
+    return createTokenTrackerLink(tokenAddress, networkId, holderAddress);
+  }
+  return createTokenTrackerLinkForChain(tokenAddress, chainId, holderAddress);
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -9,6 +9,7 @@ const {
   createExplorerLinkForChain,
   createAccountLinkForChain,
   createTokenTrackerLinkForChain,
+  getBlockExplorerUrlForTx,
 } = require('../dist');
 
 // `https://${prefix}etherscan.io/address/${address}`
@@ -157,6 +158,98 @@ describe('token-tracker-link', function () {
     it('should handle customNetwork url correctly', function () {
       const result = createCustomTokenTrackerLink('foo', 'https://data-seed-prebsc-1-s1.binance.org:8545/');
       assert.strictEqual(result, 'https://data-seed-prebsc-1-s1.binance.org:8545/token/foo', 'should return binance testnet token url');
+    });
+  });
+
+/*
+ * Test getBlockExplorerUrlForTx, 
+ * Which applies correct explorer-link generator based on args
+ */  
+  const getBlockExplorerUrlForTxTests = [
+    {
+      expected: 'https://etherscan.io/tx/0xabcd',
+      transaction: {
+        metamaskNetworkId: '1',
+        hash: '0xabcd',
+      },
+    },
+    {
+      expected: 'https://ropsten.etherscan.io/tx/0xdef0',
+      transaction: {
+        metamaskNetworkId: '3',
+        hash: '0xdef0',
+      },
+      rpcPrefs: {},
+    },
+    {
+      // test handling of `blockExplorerUrl` for a custom RPC
+      expected: 'https://block.explorer/tx/0xabcd',
+      transaction: {
+        metamaskNetworkId: '31',
+        hash: '0xabcd',
+      },
+      rpcPrefs: {
+        blockExplorerUrl: 'https://block.explorer',
+      },
+    },
+    {
+      // test handling of trailing `/` in `blockExplorerUrl` for a custom RPC
+      expected: 'https://another.block.explorer/tx/0xdef0',
+      transaction: {
+        networkId: '33',
+        hash: '0xdef0',
+      },
+      rpcPrefs: {
+        blockExplorerUrl: 'https://another.block.explorer/',
+      },
+    },
+    {
+      expected: 'https://etherscan.io/tx/0xabcd',
+      transaction: {
+        chainId: '0x1',
+        hash: '0xabcd',
+      },
+    },
+    {
+      expected: 'https://ropsten.etherscan.io/tx/0xdef0',
+      transaction: {
+        chainId: '0x3',
+        hash: '0xdef0',
+      },
+      rpcPrefs: {},
+    },
+    {
+      // test handling of `blockExplorerUrl` for a custom RPC
+      expected: 'https://block.explorer/tx/0xabcd',
+      transaction: {
+        chainId: '0x1f',
+        hash: '0xabcd',
+      },
+      rpcPrefs: {
+        blockExplorerUrl: 'https://block.explorer',
+      },
+    },
+    {
+      // test handling of trailing `/` in `blockExplorerUrl` for a custom RPC
+      expected: 'https://another.block.explorer/tx/0xdef0',
+      transaction: {
+        chainId: '0x21',
+        hash: '0xdef0',
+      },
+      rpcPrefs: {
+        blockExplorerUrl: 'https://another.block.explorer/',
+      },
+    },
+  ];
+  
+  describe('getBlockExplorerUrlForTx', function () {
+    getBlockExplorerUrlForTxTests.forEach((test) => {
+      it(`should return '${test.expected}' for transaction with hash: '${test.transaction.hash}'`, function () {
+        assert.strictEqual(
+          getBlockExplorerUrlForTx(test.transaction, test.rpcPrefs),
+          test.expected,
+        );
+      });
     });
   });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -10,6 +10,7 @@ const {
   createAccountLinkForChain,
   createTokenTrackerLinkForChain,
   getBlockExplorerUrlForTx,
+  getAccountLink,
 } = require('../dist');
 
 // `https://${prefix}etherscan.io/address/${address}`
@@ -51,6 +52,50 @@ describe('account-link', function () {
   it('should handle customNetwork url correctly', function () {
     const result = createCustomAccountLink('foo', 'https://data-seed-prebsc-1-s1.binance.org:8545');
     assert.strictEqual(result, 'https://data-seed-prebsc-1-s1.binance.org:8545/address/foo', 'should return binance testnet address url');
+  });
+
+  describe('getAccountLink', function () {
+    it('should return the correct account-link url for an account based on chainId, networkId and rpcPref args', function () {
+      const getAccountLinkTests = [
+        {
+          expected: 'https://etherscan.io/address/0xabcd',
+          chainId: '0x1',
+          address: '0xabcd',
+        },
+        {
+          expected: 'https://etherscan.io/address/0xabcd',
+          networkId: '1',
+          address: '0xabcd',
+        },
+        {
+          expected: 'https://ropsten.etherscan.io/address/0xdef0',
+          chainId: '0x3',
+          address: '0xdef0',
+          rpcPrefs: {},
+        },
+        {
+          // test handling of `blockExplorerUrl` for a custom RPC
+          expected: 'https://block.explorer/address/0xabcd',
+          chainId: '0x21',
+          address: '0xabcd',
+          rpcPrefs: {
+            blockExplorerUrl: 'https://block.explorer',
+          },
+        },
+        {
+          // test handling of trailing `/` in `blockExplorerUrl` for a custom RPC
+          expected: 'https://another.block.explorer/address/0xdef0',
+          chainId: '0x1f',
+          address: '0xdef0',
+          rpcPrefs: {
+            blockExplorerUrl: 'https://another.block.explorer/',
+          },
+        },
+      ];
+      getAccountLinkTests.forEach(({ expected, address, chainId, rpcPrefs, networkId }) => {
+        assert.strictEqual(getAccountLink(address, chainId, rpcPrefs, networkId), expected);
+      });
+    });
   });
 });
 
@@ -161,93 +206,94 @@ describe('token-tracker-link', function () {
     });
   });
 
-/*
- * Test getBlockExplorerUrlForTx, 
- * Which applies correct explorer-link generator based on args
- */  
-  const getBlockExplorerUrlForTxTests = [
-    {
-      expected: 'https://etherscan.io/tx/0xabcd',
-      transaction: {
-        metamaskNetworkId: '1',
-        hash: '0xabcd',
-      },
-    },
-    {
-      expected: 'https://ropsten.etherscan.io/tx/0xdef0',
-      transaction: {
-        metamaskNetworkId: '3',
-        hash: '0xdef0',
-      },
-      rpcPrefs: {},
-    },
-    {
-      // test handling of `blockExplorerUrl` for a custom RPC
-      expected: 'https://block.explorer/tx/0xabcd',
-      transaction: {
-        metamaskNetworkId: '31',
-        hash: '0xabcd',
-      },
-      rpcPrefs: {
-        blockExplorerUrl: 'https://block.explorer',
-      },
-    },
-    {
-      // test handling of trailing `/` in `blockExplorerUrl` for a custom RPC
-      expected: 'https://another.block.explorer/tx/0xdef0',
-      transaction: {
-        networkId: '33',
-        hash: '0xdef0',
-      },
-      rpcPrefs: {
-        blockExplorerUrl: 'https://another.block.explorer/',
-      },
-    },
-    {
-      expected: 'https://etherscan.io/tx/0xabcd',
-      transaction: {
-        chainId: '0x1',
-        hash: '0xabcd',
-      },
-    },
-    {
-      expected: 'https://ropsten.etherscan.io/tx/0xdef0',
-      transaction: {
-        chainId: '0x3',
-        hash: '0xdef0',
-      },
-      rpcPrefs: {},
-    },
-    {
-      // test handling of `blockExplorerUrl` for a custom RPC
-      expected: 'https://block.explorer/tx/0xabcd',
-      transaction: {
-        chainId: '0x1f',
-        hash: '0xabcd',
-      },
-      rpcPrefs: {
-        blockExplorerUrl: 'https://block.explorer',
-      },
-    },
-    {
-      // test handling of trailing `/` in `blockExplorerUrl` for a custom RPC
-      expected: 'https://another.block.explorer/tx/0xdef0',
-      transaction: {
-        chainId: '0x21',
-        hash: '0xdef0',
-      },
-      rpcPrefs: {
-        blockExplorerUrl: 'https://another.block.explorer/',
-      },
-    },
-  ];
-  
+  /*
+ * Test getBlockExplorerUrlForTx,
+  * Which applies correct explorer-link generator based on args
+  */
   describe('getBlockExplorerUrlForTx', function () {
-    getBlockExplorerUrlForTxTests.forEach((test) => {
-      it(`should return '${test.expected}' for transaction with hash: '${test.transaction.hash}'`, function () {
+    it('should return the correct block explorer url for an account based on chainId, networkId and rpcPref args', function () {
+
+      const getBlockExplorerUrlForTxTests = [
+        {
+          expected: 'https://etherscan.io/tx/0xabcd',
+          transaction: {
+            metamaskNetworkId: '1',
+            hash: '0xabcd',
+          },
+        },
+        {
+          expected: 'https://ropsten.etherscan.io/tx/0xdef0',
+          transaction: {
+            metamaskNetworkId: '3',
+            hash: '0xdef0',
+          },
+          rpcPrefs: {},
+        },
+        {
+          // test handling of `blockExplorerUrl` for a custom RPC
+          expected: 'https://block.explorer/tx/0xabcd',
+          transaction: {
+            metamaskNetworkId: '31',
+            hash: '0xabcd',
+          },
+          rpcPrefs: {
+            blockExplorerUrl: 'https://block.explorer',
+          },
+        },
+        {
+          // test handling of trailing `/` in `blockExplorerUrl` for a custom RPC
+          expected: 'https://another.block.explorer/tx/0xdef0',
+          transaction: {
+            metamaskNetworkId: '33',
+            hash: '0xdef0',
+          },
+          rpcPrefs: {
+            blockExplorerUrl: 'https://another.block.explorer/',
+          },
+        },
+        {
+          expected: 'https://etherscan.io/tx/0xabcd',
+          transaction: {
+            chainId: '0x1',
+            hash: '0xabcd',
+          },
+        },
+        {
+          expected: 'https://ropsten.etherscan.io/tx/0xdef0',
+          transaction: {
+            chainId: '0x3',
+            hash: '0xdef0',
+          },
+          rpcPrefs: {},
+        },
+        {
+          // test handling of `blockExplorerUrl` for a custom RPC
+          expected: 'https://block.explorer/tx/0xabcd',
+          transaction: {
+            chainId: '0x1f',
+            hash: '0xabcd',
+          },
+          rpcPrefs: {
+            blockExplorerUrl: 'https://block.explorer',
+          },
+        },
+        {
+          // test handling of trailing `/` in `blockExplorerUrl` for a custom RPC
+          expected: 'https://another.block.explorer/tx/0xdef0',
+          transaction: {
+            chainId: '0x21',
+            hash: '0xdef0',
+          },
+          rpcPrefs: {
+            blockExplorerUrl: 'https://another.block.explorer/',
+          },
+        },
+      ];
+
+      getBlockExplorerUrlForTxTests.forEach((test) => {
         assert.strictEqual(
           getBlockExplorerUrlForTx(test.transaction, test.rpcPrefs),
-          test.expected,
+          test.expected
         );
       });
     });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -11,6 +11,7 @@ const {
   createTokenTrackerLinkForChain,
   getBlockExplorerUrlForTx,
   getAccountLink,
+  getTokenTracker,
 } = require('../dist');
 
 // `https://${prefix}etherscan.io/address/${address}`
@@ -203,6 +204,76 @@ describe('token-tracker-link', function () {
     it('should handle customNetwork url correctly', function () {
       const result = createCustomTokenTrackerLink('foo', 'https://data-seed-prebsc-1-s1.binance.org:8545/');
       assert.strictEqual(result, 'https://data-seed-prebsc-1-s1.binance.org:8545/token/foo', 'should return binance testnet token url');
+    });
+
+    describe('getTokenTracker', function () {
+      it('should return the correct token tracker url based on chainId, networkId and rpcPref args', function () {
+
+        const getTokenTrackerTests = [
+          {
+            expected: 'https://etherscan.io/token/0xabcd',
+            networkId: '1',
+            tokenAddress: '0xabcd',
+          },
+          {
+            expected: 'https://ropsten.etherscan.io/token/0xdef0',
+            networkId: '3',
+            tokenAddress: '0xdef0',
+          },
+          {
+            // test handling of `blockExplorerUrl` for a custom RPC
+            expected: 'https://block.explorer/token/0xar31',
+            tokenAddress: '0xar31',
+            rpcPrefs: {
+              blockExplorerUrl: 'https://block.explorer',
+            },
+          },
+          {
+            // test handling of trailing `/` in `blockExplorerUrl` for a custom RPC
+            expected: 'https://another.block.explorer/token/0xdef0',
+            tokenAddress: '0xdef0',
+            rpcPrefs: {
+              blockExplorerUrl: 'https://another.block.explorer/',
+            },
+          },
+          {
+            expected: 'https://etherscan.io/token/0xabcd',
+            chainId: '0x1',
+            tokenAddress: '0xabcd',
+          },
+          {
+            expected: 'https://ropsten.etherscan.io/token/0xdef0',
+            chainId: '0x3',
+            tokenAddress: '0xdef0',
+            rpcPrefs: {},
+          },
+          {
+            // test handling of `blockExplorerUrl` for a custom RPC
+            expected: 'https://block.explorer/token/0xabcd',
+            chainId: '0x1f',
+            tokenAddress: '0xabcd',
+            rpcPrefs: {
+              blockExplorerUrl: 'https://block.explorer',
+            },
+          },
+          {
+            // test handling of trailing `/` in `blockExplorerUrl` for a custom RPC
+            expected: 'https://another.block.explorer/token/0xdef0',
+            chainId: '0x21',
+            tokenAddress: '0xdef0',
+            rpcPrefs: {
+              blockExplorerUrl: 'https://another.block.explorer/',
+            },
+          },
+        ];
+
+        getTokenTrackerTests.forEach((test) => {
+          assert.strictEqual(
+            getTokenTracker(test.tokenAddress, test.chainId, test.networkId, test.holderAddress, test.rpcPrefs),
+            test.expected
+          );
+        });
+      });
     });
   });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -9,9 +9,9 @@ const {
   createExplorerLinkForChain,
   createAccountLinkForChain,
   createTokenTrackerLinkForChain,
-  getBlockExplorerUrlForTx,
+  getBlockExplorerLink,
   getAccountLink,
-  getTokenTracker,
+  getTokenTrackerLink,
 } = require('../dist');
 
 // `https://${prefix}etherscan.io/address/${address}`
@@ -206,7 +206,7 @@ describe('token-tracker-link', function () {
       assert.strictEqual(result, 'https://data-seed-prebsc-1-s1.binance.org:8545/token/foo', 'should return binance testnet token url');
     });
 
-    describe('getTokenTracker', function () {
+    describe('getTokenTrackerLink', function () {
       it('should return the correct token tracker url based on chainId, networkId and rpcPref args', function () {
 
         const getTokenTrackerTests = [
@@ -269,7 +269,7 @@ describe('token-tracker-link', function () {
 
         getTokenTrackerTests.forEach((test) => {
           assert.strictEqual(
-            getTokenTracker(test.tokenAddress, test.chainId, test.networkId, test.holderAddress, test.rpcPrefs),
+            getTokenTrackerLink(test.tokenAddress, test.chainId, test.networkId, test.holderAddress, test.rpcPrefs),
             test.expected
           );
         });
@@ -278,13 +278,13 @@ describe('token-tracker-link', function () {
   });
 
   /*
- * Test getBlockExplorerUrlForTx,
+ * Test getBlockExplorerLink,
   * Which applies correct explorer-link generator based on args
   */
-  describe('getBlockExplorerUrlForTx', function () {
+  describe('getBlockExplorerLink', function () {
     it('should return the correct block explorer url for an account based on chainId, networkId and rpcPref args', function () {
 
-      const getBlockExplorerUrlForTxTests = [
+      const getBlockExplorerLinkTests = [
         {
           expected: 'https://etherscan.io/tx/0xabcd',
           transaction: {
@@ -361,9 +361,9 @@ describe('token-tracker-link', function () {
         },
       ];
 
-      getBlockExplorerUrlForTxTests.forEach((test) => {
+      getBlockExplorerLinkTests.forEach((test) => {
         assert.strictEqual(
-          getBlockExplorerUrlForTx(test.transaction, test.rpcPrefs),
+          getBlockExplorerLink(test.transaction, test.rpcPrefs),
           test.expected
         );
       });


### PR DESCRIPTION
The goal of this PR is to complete the pattern proposed in this [PR ](https://github.com/MetaMask/etherscan-link/pull/43). We had begun to build utility methods in the extension repo to select the appropriate url generation method (using either custom network, chainId or networkId). Here I've continued the work of lifting these selector methods into the etherscan-link repo. Ideally the selector methods (getBlockExplorerLink, getAccountLink, getTokenTrackerLink) would have a matching function signature/api however they have slightly different required arguments.

Included work:
* Lifts getAccountLink from extension repo
    * Lifts corresponding tests
* Lifts tests for getBlockExplorerLink over from extension repo.
* Creates getTokenTrackerLink for selecting appropriate token-tracker url generation method.
