### PR TITLE
v2.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [2.1.0] - 2021-05-07
+### Added
+
+- Add methods (getBlockExplorerLink, getAccountLink, getTokenTrackerLink) that select correct block explorer link format based on input params ([#31](https://github.com/MetaMask/etherscan-link/pull/44))
 
 ## [2.0.0] - 2021-03-11
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/etherscan-link",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "A library for generating etherscan links.",
   "main": "dist/index.js",
   "publishConfig": {


### PR DESCRIPTION
This release adds methods (getBlockExplorerLink, getAccountLink, getTokenTrackerLink) that select correct block explorer link format and uses the corresponding method based on the input params.