### PR TITLE
Block Explorer URL with hash tag

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -5,7 +5,7 @@ export const addPathToUrl = (customNetworkUrl: string, linkType: string, suffixT
 
   const auth = username ? `${username}:${password}` : '';
 
-  const parsedUrl = new URL(`${protocol}//${auth}${host}${newPath}${search}${hash}`);
+  const parsedUrl = new URL(`${protocol}//${auth}${host}${hash.endsWith('#/') ? '#' : hash}${newPath}${search}`);
 
   return parsedUrl.toString();
 };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -237,6 +237,14 @@ describe('token-tracker-link', function () {
             },
           },
           {
+            // test handling of trailing `#/` in `blockExplorerUrl` for a custom RPC
+            expected: 'https://another.block.explorer/#/token/0xdef0',
+            tokenAddress: '0xdef0',
+            rpcPrefs: {
+              blockExplorerUrl: 'https://another.block.explorer/#/',
+            },
+          },
+          {
             expected: 'https://etherscan.io/token/0xabcd',
             chainId: '0x1',
             tokenAddress: '0xabcd',
@@ -263,6 +271,15 @@ describe('token-tracker-link', function () {
             tokenAddress: '0xdef0',
             rpcPrefs: {
               blockExplorerUrl: 'https://another.block.explorer/',
+            },
+          },
+          {
+            // test handling of trailing `#/` in `blockExplorerUrl` for a custom RPC
+            expected: 'https://another.block.explorer/#/token/0xdef0',
+            chainId: '0x21',
+            tokenAddress: '0xdef0',
+            rpcPrefs: {
+              blockExplorerUrl: 'https://another.block.explorer/#/',
             },
           },
         ];
@@ -323,6 +340,17 @@ describe('token-tracker-link', function () {
           },
         },
         {
+          // test handling of trailing `#/` in `blockExplorerUrl` for a custom RPC
+          expected: 'https://another.block.explorer/#/tx/0xdef0',
+          transaction: {
+            metamaskNetworkId: '33',
+            hash: '0xdef0',
+          },
+          rpcPrefs: {
+            blockExplorerUrl: 'https://another.block.explorer/#/',
+          },
+        },
+        {
           expected: 'https://etherscan.io/tx/0xabcd',
           transaction: {
             chainId: '0x1',
@@ -357,6 +385,17 @@ describe('token-tracker-link', function () {
           },
           rpcPrefs: {
             blockExplorerUrl: 'https://another.block.explorer/',
+          },
+        },
+        {
+          // test handling of trailing `#/` in `blockExplorerUrl` for a custom RPC
+          expected: 'https://another.block.explorer/#/tx/0xdef0',
+          transaction: {
+            chainId: '0x21',
+            hash: '0xdef0',
+          },
+          rpcPrefs: {
+            blockExplorerUrl: 'https://another.block.explorer/#/',
           },
         },
       ];


### PR DESCRIPTION
The goal of this PR is when `blockExplorerUrl` contains a trailing `#/`, for example `https://testnet.bscscan.com/#/`, expected behavior will be like this `https://testnet.bscscan.com/#/tx/<hash>`.

Current behavior is: `https://testnet.bscscan.com/tx/<hash>#/`

This issue is realted to: https://github.com/MetaMask/metamask-extension/issues/12465